### PR TITLE
Fix generator target to netstandard2.0

### DIFF
--- a/Praefixum/IsExternalInit.cs
+++ b/Praefixum/IsExternalInit.cs
@@ -1,0 +1,4 @@
+namespace System.Runtime.CompilerServices
+{
+    internal static class IsExternalInit { }
+}

--- a/Praefixum/Praefixum.csproj
+++ b/Praefixum/Praefixum.csproj
@@ -1,5 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">  <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- Target netstandard2.0 so the generator works on older SDKs -->
+    <TargetFramework>netstandard2.0</TargetFramework>
     <OutputItemType>Analyzer</OutputItemType>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
## Summary
- target `netstandard2.0` so the generator can be consumed from older SDKs
- add missing `IsExternalInit` type

## Testing
- `dotnet build Praefixum.sln -c Release`
- `dotnet test Praefixum.sln -c Release --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6841b5c0ed50832e8e8fddc0e5eeb803