### PR TITLE
Generate UniqueId attribute only when needed

### DIFF
--- a/Praefixum.Tests/Praefixum.Tests.csproj
+++ b/Praefixum.Tests/Praefixum.Tests.csproj
@@ -31,9 +31,9 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\Praefixum\Praefixum.csproj" 
-                      OutputItemType="Analyzer" 
-                      ReferenceOutputAssembly="true" />
+    <ProjectReference Include="..\Praefixum\Praefixum.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/Praefixum/Praefixum.csproj
+++ b/Praefixum/Praefixum.csproj
@@ -53,8 +53,6 @@
     <!-- Include the source generator as an analyzer -->
     <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers\dotnet\cs\$(AssemblyName).dll" Visible="false" />
     
-    <!-- Include the assembly in lib folder for attributes -->
-    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="lib\netstandard2.0\$(AssemblyName).dll" Visible="false" />
   </ItemGroup>
   <!-- Build targets to ensure proper analyzer reference -->
   <ItemGroup>


### PR DESCRIPTION
## Summary
- revert demo and tests to use analyzer-only project reference
- ship generator as analyzer again
- remove library copy of `UniqueIdAttribute`
- keep generator's private enum for internal use

## Testing
- `dotnet build Praefixum.Tests/Praefixum.Tests.csproj -v minimal` *(fails: NETSDK1045 - .NET 9.0 not supported by SDK 8.0)*

------
https://chatgpt.com/codex/tasks/task_e_6852da054028832e94c5bb962467c2ae