### PR TITLE
Reference shared attributes in generator

### DIFF
--- a/Praefixum.Attributes/Praefixum.Attributes.csproj
+++ b/Praefixum.Attributes/Praefixum.Attributes.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+</Project>

--- a/Praefixum.Attributes/UniqueIdAttribute.cs
+++ b/Praefixum.Attributes/UniqueIdAttribute.cs
@@ -1,0 +1,25 @@
+namespace Praefixum
+{
+    [System.AttributeUsage(System.AttributeTargets.Parameter)]
+    public sealed class UniqueIdAttribute : System.Attribute
+    {
+        public UniqueIdFormat Format { get; }
+        public string? Prefix { get; }
+        public bool Deterministic { get; }
+
+        public UniqueIdAttribute(UniqueIdFormat format = UniqueIdFormat.Guid, string? prefix = null, bool deterministic = true)
+        {
+            Format = format;
+            Prefix = prefix;
+            Deterministic = deterministic;
+        }
+    }
+
+    public enum UniqueIdFormat
+    {
+        Guid,
+        HtmlId,
+        Timestamp,
+        ShortHash
+    }
+}

--- a/Praefixum.Demo/Praefixum.Demo.csproj
+++ b/Praefixum.Demo/Praefixum.Demo.csproj
@@ -12,5 +12,6 @@
     <ProjectReference Include="..\Praefixum\Praefixum.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Praefixum.Attributes\Praefixum.Attributes.csproj" />
   </ItemGroup>
 </Project>

--- a/Praefixum.Tests/Praefixum.Tests.csproj
+++ b/Praefixum.Tests/Praefixum.Tests.csproj
@@ -34,9 +34,10 @@
   </ItemGroup>
   
   <ItemGroup>
-    <ProjectReference Include="..\Praefixum\Praefixum.csproj" 
-                      OutputItemType="Analyzer" 
+    <ProjectReference Include="..\Praefixum\Praefixum.csproj"
+                      OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Praefixum.Attributes\Praefixum.Attributes.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Praefixum.sln
+++ b/Praefixum.sln
@@ -1,3 +1,4 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
@@ -7,6 +8,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Praefixum.Demo", "Praefixum.Demo\Praefixum.Demo.csproj", "{CE9212C6-4877-4AFE-BBF3-33B4EA66C73E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Praefixum.Tests", "Praefixum.Tests\Praefixum.Tests.csproj", "{A1B2C3D4-E5F6-4007-A1CC-F9FDA53375C1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Praefixum.Attributes", "Praefixum.Attributes\Praefixum.Attributes.csproj", "{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -54,6 +57,18 @@ Global
 		{A1B2C3D4-E5F6-4007-A1CC-F9FDA53375C1}.Release|x64.Build.0 = Release|Any CPU
 		{A1B2C3D4-E5F6-4007-A1CC-F9FDA53375C1}.Release|x86.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-E5F6-4007-A1CC-F9FDA53375C1}.Release|x86.Build.0 = Release|Any CPU
+		{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}.Debug|x64.Build.0 = Debug|Any CPU
+		{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}.Debug|x86.Build.0 = Debug|Any CPU
+		{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}.Release|x64.ActiveCfg = Release|Any CPU
+		{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}.Release|x64.Build.0 = Release|Any CPU
+		{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}.Release|x86.ActiveCfg = Release|Any CPU
+		{9319B6A4-E0F4-4CCA-BE63-F689FAAC9949}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Praefixum/Praefixum.csproj
+++ b/Praefixum/Praefixum.csproj
@@ -11,6 +11,7 @@
     <!-- Disable nullable warnings -->
     <NoWarn>CS8602</NoWarn>
     <InterceptorsNamespaces>$(InterceptorsNamespaces);Praefixum</InterceptorsNamespaces>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0">
@@ -52,9 +53,14 @@
   <ItemGroup>
     <!-- Include the source generator as an analyzer -->
     <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="analyzers\dotnet\cs\$(AssemblyName).dll" Visible="false" />
-    
-    <!-- Include the assembly in lib folder for attributes -->
-    <None Include="$(OutputPath)$(AssemblyName).dll" Pack="true" PackagePath="lib\netstandard2.0\$(AssemblyName).dll" Visible="false" />
+
+    <!-- Include the attributes assembly in lib folder -->
+    <None Include="..\Praefixum.Attributes\bin\$(Configuration)\netstandard2.0\Praefixum.Attributes.dll" Pack="true" PackagePath="lib\netstandard2.0\Praefixum.Attributes.dll" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Reference attribute definitions for compile-time use -->
+    <ProjectReference Include="..\Praefixum.Attributes\Praefixum.Attributes.csproj" PrivateAssets="all" />
   </ItemGroup>
   <!-- Build targets to ensure proper analyzer reference -->
   <ItemGroup>

--- a/Praefixum/UniqueIdGenerator.cs
+++ b/Praefixum/UniqueIdGenerator.cs
@@ -9,50 +9,14 @@ using System.Text;
 
 namespace Praefixum;
 
-// Enum used by the source generator internally
-internal enum UniqueIdFormat
-{
-    Guid,
-    HtmlId,
-    Timestamp,
-    ShortHash
-}
+// Uses UniqueIdAttribute and UniqueIdFormat from Praefixum.Attributes
 
 [Generator]
 public sealed class PraefixumSourceGenerator : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
-    {        // Register the attribute source first
-        context.RegisterPostInitializationOutput(ctx =>
-        {            ctx.AddSource("UniqueIdAttribute.g.cs", SourceText.From("""
-                #nullable enable
-                namespace Praefixum
-                {
-                    [System.AttributeUsage(System.AttributeTargets.Parameter)]
-                    public sealed class UniqueIdAttribute : System.Attribute
-                    {
-                        public UniqueIdFormat Format { get; }
-                        public string? Prefix { get; }
-                        public bool Deterministic { get; }
-
-                        public UniqueIdAttribute(UniqueIdFormat format = UniqueIdFormat.Guid, string? prefix = null, bool deterministic = true)
-                        {
-                            Format = format;
-                            Prefix = prefix;
-                            Deterministic = deterministic;
-                        }
-                    }
-
-                    public enum UniqueIdFormat
-                    {
-                        Guid,
-                        HtmlId,
-                        Timestamp,
-                        ShortHash
-                    }
-                }
-                """, Encoding.UTF8));
-        });
+    {
+        // Attribute definitions are provided by the Praefixum.Attributes assembly
 
         // Find method calls that need interception
         var methodCallsProvider = context.SyntaxProvider


### PR DESCRIPTION
## Summary
- include `Praefixum.Attributes` project in the generator build
- remove internal copies of `UniqueIdAttribute` and `UniqueIdFormat`
- generator now uses the shared attribute types

## Testing
- `dotnet test` *(fails: NETSDK1045 because SDK 9.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a3af113d8832ebef8e84a91feb527